### PR TITLE
Et3 response save documents

### DIFF
--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -2227,6 +2227,36 @@
   },
   {
     "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "UserRole": "caseworker-employment",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "UserRole": "caseworker-employment-etjudge",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "UserRole": "caseworker-employment-englandwales",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "UserRole": "caseworker-employment-etjudge-englandwales",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
     "CaseFieldID": "correspondenceType",
     "UserRole": "caseworker-employment",
     "CRUD": "R"

--- a/definitions/json/CaseEvent.json
+++ b/definitions/json/CaseEvent.json
@@ -93,7 +93,7 @@
     "ShowEventNotes": "N",
     "ShowSummary": "Y",
     "CallBackURLAboutToStartEvent": "${ET_COS_URL}/et3Response/aboutToStart",
-    "CallBackURLAboutToSubmitEvent": "",
+    "CallBackURLAboutToSubmitEvent": "${ET_COS_URL}/et3Response/aboutToSubmit",
     "CallBackURLSubmittedEvent": "${ET_COS_URL}/et3Response/processingComplete",
     "EventEnablingCondition": ""
   },

--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -218,6 +218,15 @@
   },
   {
     "CaseTypeID": "ET_EnglandWales",
+    "ID": "et3ResponseDocumentCollection",
+    "Label": "ET3 response documentation",
+    "HintText": "Upload documentation for the case",
+    "FieldType": "Collection",
+    "FieldTypeParameter": "DocumentUpload",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
     "ID": "additionalCaseInfo",
     "Label": "Additional information",
     "HintText": "Additional case information",

--- a/definitions/json/CaseTypeTab.json
+++ b/definitions/json/CaseTypeTab.json
@@ -1013,6 +1013,15 @@
   {
     "CaseTypeID": "ET_EnglandWales",
     "Channel": "CaseWorker",
+    "TabID": "CaseDocuments",
+    "TabLabel": "Documents",
+    "TabDisplayOrder": 14,
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "TabFieldDisplayOrder": 1
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
+    "Channel": "CaseWorker",
     "TabID": "CaseHistory",
     "TabLabel": "History",
     "TabDisplayOrder": 15,


### PR DESCRIPTION
### Change description ###
Added function to save the documents submitted in the ET3 Response form onto the document tab


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
