### PR TITLE
RET-2238: ET1 case vetting now available on states: Rejected;Vetted

### DIFF
--- a/definitions/json/CaseEvent.json
+++ b/definitions/json/CaseEvent.json
@@ -49,7 +49,7 @@
     "Name": "ET1 case vetting",
     "Description": "Vetting a case",
     "DisplayOrder": 5,
-    "PreConditionState(s)": "Submitted",
+    "PreConditionState(s)": "Submitted;Rejected;Vetted",
     "CallBackURLAboutToStartEvent": "${ET_COS_URL}/initialiseEt1Vetting",
     "CallBackURLSubmittedEvent": "${ET_COS_URL}/finishEt1Vetting",
     "PostConditionState": "Vetted",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-2238

### Change description ###

RET-2238: ET1 case vetting now available on states: Rejected;Vetted

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
