### PR TITLE
removed et3ResponseDocument field

### DIFF
--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -2990,14 +2990,6 @@
   },
   {
     "CaseTypeID": "ET_EnglandWales",
-    "ID": "et3ResponseDocument",
-    "Label": " ",
-    "FieldType": "Document",
-    "FieldTypeParameter": "DocumentUpload",
-    "SecurityClassification": "Public"
-  },
-  {
-    "CaseTypeID": "ET_EnglandWales",
     "ID": "referralCollection",
     "Label": "Referrals",
     "FieldType": "Collection",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-2411

### Change description ###

Removed et3ResponseDocument field as we're storing et3 response documents in documentCollection now

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
