### PR TITLE
RET-2843: Added missing authorisations and respondentId field in resp…

### DIFF
--- a/definitions/json/AuthorisationCaseEvent.json
+++ b/definitions/json/AuthorisationCaseEvent.json
@@ -1132,6 +1132,13 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeId": "ET_EnglandWales",
+    "CaseEventID": "updateRepresentation",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeId": "ET_EnglandWales",
     "CaseEventID": "applyNocDecision",
     "UserRole": "caseworker-approver",
     "CRUD": "CRUD"

--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -9252,6 +9252,12 @@
     "CRUD": "CRU"
   },
   {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "changeOrganisationRequestField",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRU"
+  },
+  {
     "CaseTypeId": "ET_EnglandWales_Listings",
     "CaseFieldID": "listingDate",
     "UserRole": "caseworker-employment-englandwales",

--- a/definitions/json/CaseEvent.json
+++ b/definitions/json/CaseEvent.json
@@ -210,6 +210,7 @@
     "PostConditionState": "*",
     "CallBackURLAboutToStartEvent": "${ET_COS_URL}/dynamicRespondentRepresentativeNames",
     "CallBackURLAboutToSubmitEvent": "${ET_COS_URL}/amendRespondentRepresentative",
+    "CallBackURLSubmittedEvent": "${ET_COS_URL}/amendRespondentRepSubmitted",
     "SecurityClassification": "Public",
     "ShowEventNotes": "N"
   },

--- a/definitions/json/ComplexTypes.json
+++ b/definitions/json/ComplexTypes.json
@@ -1188,6 +1188,14 @@
   },
   {
     "ID": "RespondentRepresentative",
+    "ListElementCode": "respondentId",
+    "FieldType": "Text",
+    "ElementLabel": "Respondent Id",
+    "FieldShowCondition": "resp_rep_name=\"dummy\"",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "RespondentRepresentative",
     "ListElementCode": "dynamic_resp_rep_name",
     "FieldType": "DynamicList",
     "ElementLabel": "Respondent who is being represented",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2843


### Change description ###
Added missing authorisations and respondentId field in respondent rep


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
