### PR TITLE
linkedCaseCT label display fix

### DIFF
--- a/definitions/json/CaseTypeTab.json
+++ b/definitions/json/CaseTypeTab.json
@@ -192,7 +192,7 @@
     "TabID": "CaseOverview",
     "CaseFieldID": "linkedCaseCTLabel",
     "TabFieldDisplayOrder": 24,
-    "FieldShowCondition": "linkedCaseCT=\"*\""
+    "FieldShowCondition": "linkedCaseCT!=\"\""
   },
   {
     "CaseTypeID": "ET_EnglandWales",

--- a/definitions/json/CaseTypeTab.json
+++ b/definitions/json/CaseTypeTab.json
@@ -199,7 +199,7 @@
     "Channel": "CaseWorker",
     "TabID": "CaseOverview",
     "CaseFieldID": "ethosCaseReference",
-    "TabFieldDisplayOrder": 24,
+    "TabFieldDisplayOrder": 25,
     "FieldShowCondition": "caseType=\"dummy\""
   },
   {


### PR DESCRIPTION
The FieldShowCondition for linkedCaseCTLabel is set to linkedCaseCT!=“”. It used to be linkedCaseCT=“*”.  Fix went in CaseTyepTab, row 29.


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[ X ] No
```
