### PR TITLE
RET-2879: Added 2500 max to the response box for Pse Respond

### DIFF
--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -4404,7 +4404,8 @@
     "Label": "What's your response to the tribunal?",
     "HintText": "Use this box to provide your answer or you can upload material at the next step.",
     "FieldType": "TextArea",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "Max": "2500"
   },
   {
     "CaseTypeID": "ET_EnglandWales",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-2879

### Change description ###

Added 2500 max to the response box for Pse Respond

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
