### PR TITLE
RET-3085: Added submitted page for respondent bundles

### DIFF
--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -24274,5 +24274,53 @@
     "CaseFieldID": "bundlesRespondentUploadFile",
     "UserRole": "caseworker-employment-api",
     "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "bundlesRespondentCollection",
+    "UserRole": "et-acas-api",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "bundlesRespondentCollection",
+    "UserRole": "caseworker-employment",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "bundlesRespondentCollection",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "bundlesRespondentCollection",
+    "UserRole": "caseworker-employment-etjudge",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "bundlesRespondentCollection",
+    "UserRole": "caseworker-employment-etjudge-englandwales",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "bundlesRespondentCollection",
+    "UserRole": "caseworker-employment-englandwales",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "bundlesRespondentCollection",
+    "UserRole": "citizen",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "bundlesRespondentCollection",
+    "UserRole": "caseworker-employment-legalrep-solicitor",
+    "CRUD": "CRU"
   }
 ]

--- a/definitions/json/CaseEvent.json
+++ b/definitions/json/CaseEvent.json
@@ -900,6 +900,7 @@
     "ID": "bundlesRespondentPrepareDoc",
     "Name": "Prepare documents for hearing",
     "Description": "Prepare documents for a hearing",
+    "DisplayOrder": 1,
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
@@ -908,7 +909,7 @@
     "EventEnablingCondition": " ",
     "CallBackURLAboutToStartEvent": "${ET_COS_URL}/bundlesRespondent/aboutToStart",
     "CallBackURLAboutToSubmitEvent": "${ET_COS_URL}/bundlesRespondent/aboutToSubmit",
-    "CallBackURLSubmittedEvent": ""
+    "CallBackURLSubmittedEvent": "${ET_COS_URL}/bundlesRespondent/submitted"
   },
   {
     "CaseTypeID": "ET_EnglandWales_Listings",

--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -4676,6 +4676,14 @@
     "SecurityClassification": "Public"
   },
   {
+    "CaseTypeID": "ET_EnglandWales",
+    "ID": "bundlesRespondentCollection",
+    "Label": "Hearing Bundles",
+    "FieldType": "Collection",
+    "FieldTypeParameter": "HearingBundle",
+    "SecurityClassification": "Public"
+  },
+  {
     "CaseTypeID": "ET_EnglandWales_Listings",
     "ID": "hearingDateType",
     "Label": "Single or Range",

--- a/definitions/json/ComplexTypes.json
+++ b/definitions/json/ComplexTypes.json
@@ -7081,5 +7081,55 @@
     "ElementLabel": "Sent to",
     "SecurityClassification": "Public",
     "DisplayOrder": 10
+  },
+  {
+    "ID": "HearingBundle",
+    "ListElementCode": "agreedDocWith",
+    "FieldType": "Text",
+    "ElementLabel": "Have you agreed these documents with the other party?",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "HearingBundle",
+    "ListElementCode": "agreedDocWithBut",
+    "FieldType": "Text",
+    "ElementLabel": "Which documents are disputed",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "HearingBundle",
+    "ListElementCode": "agreedWithNo",
+    "FieldType": "Text",
+    "ElementLabel": "Why you've not been able to agree with the other party",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "HearingBundle",
+    "ListElementCode": "hearing",
+    "FieldType": "Text",
+    "ElementLabel": "Hearing these documents are for",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "HearingBundle",
+    "ListElementCode": "uploadFile",
+    "FieldType": "Document",
+    "ElementLabel": "Document",
+    "FieldTypeParameter": "DocumentUpload",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "HearingBundle",
+    "ListElementCode": "whatDocuments",
+    "FieldType": "Text",
+    "ElementLabel": "What are these hearing documents?",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "HearingBundle",
+    "ListElementCode": "whoseDocuments",
+    "FieldType": "Text",
+    "ElementLabel": "Whose hearing documents are you uploading?",
+    "SecurityClassification": "Public"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3085

### Change description ###

Added submitted page for respondent bundles

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
