### PR TITLE
RET-3804

### DIFF
--- a/definitions/json/CaseEvent.json
+++ b/definitions/json/CaseEvent.json
@@ -600,7 +600,7 @@
     "Name": "Case Transfer to ECM",
     "Description": "Transfer case to ECM system",
     "DisplayOrder": 39,
-    "PreConditionState(s)": "*",
+    "PreConditionState(s)": "Submitted;AWAITING_SUBMISSION_TO_HMCTS;Vetted;Accepted;Closed;Rejected",
     "PostConditionState": "Transferred",
     "CallBackURLAboutToSubmitEvent": "${ET_COS_URL}/caseTransfer/transferToEcm",
     "SecurityClassification": "Public",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3804

### Change description ###

When a user views a case in a transferred state, they must not be able to see or select the 'Case transfer to ECM' option on the next step menu.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
