### PR TITLE
RET-3794: new complex field for distinguishing Tribunal's request/ord…

### DIFF
--- a/definitions/json/CaseEventToFields.json
+++ b/definitions/json/CaseEventToFields.json
@@ -5855,8 +5855,8 @@
     "CaseEventID": "respondentTSE",
     "CaseFieldID": "resTseTextBox3",
     "DisplayContext": "OPTIONAL",
-    "PageID": 6,
-    "PageDisplayOrder": 6,
+    "PageID": 5,
+    "PageDisplayOrder": 5,
     "PageFieldDisplayOrder": 3,
     "ShowSummaryChangeOption": "Y"
   },

--- a/definitions/json/ComplexTypes.json
+++ b/definitions/json/ComplexTypes.json
@@ -6633,6 +6633,13 @@
     "SecurityClassification": "Public"
   },
   {
+    "ID": "tseReply",
+    "ListElementCode": "respondentResponded",
+    "FieldType": "Text",
+    "ElementLabel": "If respondent has responded",
+    "SecurityClassification": "Public"
+  },
+  {
     "ID": "genericTseDetails",
     "ListElementCode": "number",
     "FieldType": "Text",


### PR DESCRIPTION
RET-3794: new complex field for distinguishing Tribunal's request/order is responded by Respondent



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
