### PR TITLE
RET-3794: Added new fields for TSE Respondent respond mid event valid…

### DIFF
--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -17629,49 +17629,49 @@
   },
   {
     "CaseTypeId": "ET_EnglandWales",
-    "CaseFieldID": "tseRespondToTribunal",
+    "CaseFieldID": "tseRespondingToTribunal",
     "UserRole": "et-acas-api",
     "CRUD": "R"
   },
   {
     "CaseTypeId": "ET_EnglandWales",
-    "CaseFieldID": "tseRespondToTribunal",
+    "CaseFieldID": "tseRespondingToTribunal",
     "UserRole": "caseworker-employment",
     "CRUD": "R"
   },
   {
     "CaseTypeId": "ET_EnglandWales",
-    "CaseFieldID": "tseRespondToTribunal",
+    "CaseFieldID": "tseRespondingToTribunal",
     "UserRole": "caseworker-employment-api",
     "CRUD": "CRUD"
   },
   {
     "CaseTypeId": "ET_EnglandWales",
-    "CaseFieldID": "tseRespondToTribunal",
+    "CaseFieldID": "tseRespondingToTribunal",
     "UserRole": "caseworker-employment-legalrep-solicitor",
     "CRUD": "CRU"
   },
   {
     "CaseTypeId": "ET_EnglandWales",
-    "CaseFieldID": "tseRespondToTribunalText",
+    "CaseFieldID": "tseRespondingToTribunalText",
     "UserRole": "et-acas-api",
     "CRUD": "R"
   },
   {
     "CaseTypeId": "ET_EnglandWales",
-    "CaseFieldID": "tseRespondToTribunalText",
+    "CaseFieldID": "tseRespondingToTribunalText",
     "UserRole": "caseworker-employment",
     "CRUD": "R"
   },
   {
     "CaseTypeId": "ET_EnglandWales",
-    "CaseFieldID": "tseRespondToTribunalText",
+    "CaseFieldID": "tseRespondingToTribunalText",
     "UserRole": "caseworker-employment-api",
     "CRUD": "CRUD"
   },
   {
     "CaseTypeId": "ET_EnglandWales",
-    "CaseFieldID": "tseRespondToTribunalText",
+    "CaseFieldID": "tseRespondingToTribunalText",
     "UserRole": "caseworker-employment-legalrep-solicitor",
     "CRUD": "CRU"
   },

--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -17599,6 +17599,12 @@
   },
   {
     "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "tseResponseConsider",
+    "UserRole": "caseworker-employment-legalrep-solicitor",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
     "CaseFieldID": "tseResponseText",
     "UserRole": "et-acas-api",
     "CRUD": "R"
@@ -17618,6 +17624,54 @@
   {
     "CaseTypeId": "ET_EnglandWales",
     "CaseFieldID": "tseResponseText",
+    "UserRole": "caseworker-employment-legalrep-solicitor",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "tseRespondToTribunal",
+    "UserRole": "et-acas-api",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "tseRespondToTribunal",
+    "UserRole": "caseworker-employment",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "tseRespondToTribunal",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "tseRespondToTribunal",
+    "UserRole": "caseworker-employment-legalrep-solicitor",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "tseRespondToTribunalText",
+    "UserRole": "et-acas-api",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "tseRespondToTribunalText",
+    "UserRole": "caseworker-employment",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "tseRespondToTribunalText",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "tseRespondToTribunalText",
     "UserRole": "caseworker-employment-legalrep-solicitor",
     "CRUD": "CRU"
   },

--- a/definitions/json/CaseEventToFields.json
+++ b/definitions/json/CaseEventToFields.json
@@ -6268,6 +6268,7 @@
     "FieldShowCondition": "tseResponseIntroLabel=\"dummy\"",
     "RetainHiddenValue": "No",
     "ShowSummaryChangeOption": "Y",
+    "CallBackURLMidEvent": "${ET_COS_URL}/tseResponse/midValidateInput",
     "PageLabel": "Your response"
   },
   {
@@ -6311,11 +6312,33 @@
   {
     "CaseTypeID": "ET_EnglandWales",
     "CaseEventID": "tseRespond",
+    "CaseFieldID": "tseRespondToTribunal",
+    "DisplayContext": "READONLY",
+    "PageID": 3,
+    "PageDisplayOrder": 3,
+    "PageFieldDisplayOrder": 6,
+    "FieldShowCondition": "tseResponseTableLabel=\"dummy\""
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
+    "CaseEventID": "tseRespond",
     "CaseFieldID": "tseResponseText",
     "DisplayContext": "OPTIONAL",
     "PageID": 3,
     "PageDisplayOrder": 3,
-    "PageFieldDisplayOrder": 6,
+    "PageFieldDisplayOrder": 7,
+    "FieldShowCondition": "tseRespondToTribunal!=\"Yes\"",
+    "ShowSummaryChangeOption": "Y"
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
+    "CaseEventID": "tseRespond",
+    "CaseFieldID": "tseRespondToTribunalText",
+    "DisplayContext": "OPTIONAL",
+    "PageID": 3,
+    "PageDisplayOrder": 3,
+    "PageFieldDisplayOrder": 8,
+    "FieldShowCondition": "tseRespondToTribunal=\"Yes\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -6325,7 +6348,7 @@
     "DisplayContext": "MANDATORY",
     "PageID": 3,
     "PageDisplayOrder": 3,
-    "PageFieldDisplayOrder": 7,
+    "PageFieldDisplayOrder": 9,
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/definitions/json/CaseEventToFields.json
+++ b/definitions/json/CaseEventToFields.json
@@ -6312,7 +6312,7 @@
   {
     "CaseTypeID": "ET_EnglandWales",
     "CaseEventID": "tseRespond",
-    "CaseFieldID": "tseRespondToTribunal",
+    "CaseFieldID": "tseRespondingToTribunal",
     "DisplayContext": "READONLY",
     "PageID": 3,
     "PageDisplayOrder": 3,
@@ -6327,18 +6327,18 @@
     "PageID": 3,
     "PageDisplayOrder": 3,
     "PageFieldDisplayOrder": 7,
-    "FieldShowCondition": "tseRespondToTribunal!=\"Yes\"",
+    "FieldShowCondition": "tseRespondingToTribunal!=\"Yes\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
     "CaseTypeID": "ET_EnglandWales",
     "CaseEventID": "tseRespond",
-    "CaseFieldID": "tseRespondToTribunalText",
+    "CaseFieldID": "tseRespondingToTribunalText",
     "DisplayContext": "OPTIONAL",
     "PageID": 3,
     "PageDisplayOrder": 3,
     "PageFieldDisplayOrder": 8,
-    "FieldShowCondition": "tseRespondToTribunal=\"Yes\"",
+    "FieldShowCondition": "tseRespondingToTribunal=\"Yes\"",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -4039,7 +4039,7 @@
   },
   {
     "CaseTypeID": "ET_EnglandWales",
-    "ID": "tseRespondToTribunalText",
+    "ID": "tseRespondingToTribunalText",
     "Label": "What's your response to the tribunal?",
     "HintText": "Use this box to provide your answer or you can upload material at the next step.",
     "FieldType": "TextArea",
@@ -4047,7 +4047,7 @@
   },
   {
     "CaseTypeID": "ET_EnglandWales",
-    "ID": "tseRespondToTribunal",
+    "ID": "tseRespondingToTribunal",
     "Label": "Respondent is responding to Tribunal request/order",
     "FieldType": "TextArea",
     "SecurityClassification": "Public"

--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -4039,6 +4039,21 @@
   },
   {
     "CaseTypeID": "ET_EnglandWales",
+    "ID": "tseRespondToTribunalText",
+    "Label": "What's your response to the tribunal?",
+    "HintText": "Use this box to provide your answer or you can upload material at the next step.",
+    "FieldType": "TextArea",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
+    "ID": "tseRespondToTribunal",
+    "Label": "Respondent is responding to Tribunal request/order",
+    "FieldType": "TextArea",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
     "ID": "tseResponseHasSupportingMaterial",
     "Label": "Supporting material",
     "HintText": "Do you have any supporting material you want to provide?",


### PR DESCRIPTION



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
