### PR TITLE
RET-3514 Allow Non System Users Respond to an Application

### DIFF
--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -16279,6 +16279,24 @@
   },
   {
     "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "systemUserYesOrNo",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "systemUserYesOrNo",
+    "UserRole": "et-acas-api",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "systemUserYesOrNo",
+    "UserRole": "caseworker-employment-legalrep-solicitor",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
     "CaseFieldID": "resTseHorizontalLine",
     "UserRole": "caseworker-employment-api",
     "CRUD": "CRUD"
@@ -16310,6 +16328,24 @@
   {
     "CaseTypeId": "ET_EnglandWales",
     "CaseFieldID": "resTseCopyThisCorrespondenceText",
+    "UserRole": "caseworker-employment-legalrep-solicitor",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "resTseCopyThisCorrespondenceTextBold",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "resTseCopyThisCorrespondenceTextBold",
+    "UserRole": "et-acas-api",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_EnglandWales",
+    "CaseFieldID": "resTseCopyThisCorrespondenceTextBold",
     "UserRole": "caseworker-employment-legalrep-solicitor",
     "CRUD": "CRU"
   },

--- a/definitions/json/CaseEventToFields.json
+++ b/definitions/json/CaseEventToFields.json
@@ -6219,11 +6219,32 @@
   {
     "CaseTypeID": "ET_EnglandWales",
     "CaseEventID": "respondentTSE",
+    "CaseFieldID": "systemUserYesOrNo",
+    "DisplayContext": "READONLY",
+    "PageID": 14,
+    "PageDisplayOrder": 14,
+    "PageFieldDisplayOrder": 3,
+    "PageLabel": "Select an application",
+    "FieldShowCondition": "resTseCopyThisCorrespondenceText = \"Dummy\""
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
+    "CaseEventID": "respondentTSE",
+    "CaseFieldID": "resTseCopyThisCorrespondenceTextBold",
+    "DisplayContext": "READONLY",
+    "PageID": 14,
+    "PageDisplayOrder": 14,
+    "PageFieldDisplayOrder": 4,
+    "FieldShowCondition": "systemUserYesOrNo =\"No\""
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
+    "CaseEventID": "respondentTSE",
     "CaseFieldID": "resTseCopyToOtherPartyYesOrNo",
     "DisplayContext": "MANDATORY",
     "PageID": 14,
     "PageDisplayOrder": 14,
-    "PageFieldDisplayOrder": 3,
+    "PageFieldDisplayOrder": 5,
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -6233,7 +6254,7 @@
     "DisplayContext": "MANDATORY",
     "PageID": 14,
     "PageDisplayOrder": 14,
-    "PageFieldDisplayOrder": 4,
+    "PageFieldDisplayOrder": 6,
     "FieldShowCondition": "resTseCopyToOtherPartyYesOrNo=\"No\"",
     "ShowSummaryChangeOption": "Y"
   },
@@ -6432,11 +6453,32 @@
   {
     "CaseTypeID": "ET_EnglandWales",
     "CaseEventID": "tseRespond",
+    "CaseFieldID": "systemUserYesOrNo",
+    "DisplayContext": "READONLY",
+    "PageID": 5,
+    "PageDisplayOrder": 5,
+    "PageFieldDisplayOrder": 2,
+    "PageLabel": "Select an application",
+    "FieldShowCondition": "tseRespondCopyPartyIntro = \"Dummy\""
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
+    "CaseEventID": "tseRespond",
+    "CaseFieldID": "resTseCopyThisCorrespondenceTextBold",
+    "DisplayContext": "READONLY",
+    "PageID": 5,
+    "PageDisplayOrder": 5,
+    "PageFieldDisplayOrder": 3,
+    "FieldShowCondition": "systemUserYesOrNo =\"No\""
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
+    "CaseEventID": "tseRespond",
     "CaseFieldID": "tseResponseCopyToOtherParty",
     "DisplayContext": "MANDATORY",
     "PageID": 5,
     "PageDisplayOrder": 5,
-    "PageFieldDisplayOrder": 2,
+    "PageFieldDisplayOrder": 4,
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -6446,7 +6488,7 @@
     "DisplayContext": "MANDATORY",
     "PageID": 5,
     "PageDisplayOrder": 5,
-    "PageFieldDisplayOrder": 3,
+    "PageFieldDisplayOrder": 5,
     "FieldShowCondition": "tseResponseCopyToOtherParty=\"No\"",
     "RetainHiddenValue": "Yes",
     "ShowSummaryChangeOption": "Y"

--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -3597,6 +3597,13 @@
   },
   {
     "CaseTypeID": "ET_EnglandWales",
+    "ID": "systemUserYesOrNo",
+    "FieldType": "YesOrNo",
+    "Label": "Dummy Label This Field is used only check for showing resTseCopyThisCorrespondenceTextBold field or not",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
     "ID": "resTseHorizontalLine",
     "Label": "<hr>",
     "FieldType": "Label",
@@ -3606,6 +3613,13 @@
     "CaseTypeID": "ET_EnglandWales",
     "ID": "resTseCopyThisCorrespondenceText",
     "Label": "The tribunal must operate in a way fair to both sides. This means that each party must see or hear what the other party tells the tribunal. The rules therefore require all communications with the tribunal to be copied to the other party, apart from in exceptional circumstances.",
+    "FieldType": "Label",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_EnglandWales",
+    "ID": "resTseCopyThisCorrespondenceTextBold",
+    "Label": "<strong>To copy this correspondence to the other party, you must send it to them by post or email. They cannot view it in this service.</strong>",
     "FieldType": "Label",
     "SecurityClassification": "Public"
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3514

-----

### Change description ###

Removed the control for claimants who are not system users. And added the text resTseCopyThisCorrespondenceTextBold

-----

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
