### PR TITLE
RET-4898: Remove caseworker-employment-etjudge

### DIFF
--- a/definitions/json/RoleToAccessProfiles/RoleToAccessProfiles-prod.json
+++ b/definitions/json/RoleToAccessProfiles/RoleToAccessProfiles-prod.json
@@ -7,6 +7,13 @@
     "AccessProfiles": "caseworker-employment"
   },
   {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "ET_EnglandWales",
+    "RoleName": "idam:caseworker-employment-etjudge",
+    "ReadOnly": "Y",
+    "AccessProfiles": "caseworker-employment-etjudge"
+  },
+  {
     "RoleName": "specific-access-legal-ops",
     "Authorisation": "",
     "CaseTypeID": "ET_EnglandWales",

--- a/definitions/json/RoleToAccessProfiles/RoleToAccessProfiles.json
+++ b/definitions/json/RoleToAccessProfiles/RoleToAccessProfiles.json
@@ -9,13 +9,6 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "ET_EnglandWales",
-    "RoleName": "idam:caseworker-employment-etjudge",
-    "ReadOnly": "Y",
-    "AccessProfiles": "caseworker-employment-etjudge"
-  },
-  {
-    "LiveFrom": "01/01/2017",
-    "CaseTypeID": "ET_EnglandWales",
     "RoleName": "idam:caseworker-employment-englandwales",
     "ReadOnly": "N",
     "AccessProfiles": "caseworker-employment-englandwales"


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RET-4898

### Change description ###
Judges with the XUI enabling idam role (caseworker-employment-etjudge) shouldn't have full caseworker-employment-etjudge for both EW and Scotland

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
